### PR TITLE
Add base ansible docker file

### DIFF
--- a/.github/workflows/build-and-push-ansible-image.yaml
+++ b/.github/workflows/build-and-push-ansible-image.yaml
@@ -1,0 +1,37 @@
+---
+name: build-and-push-ansible-image
+
+on:
+  workflow_dispatch:
+    manual: true
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/actions/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PWD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push database minitwit
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/devops2024-group-e/ansible:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV ANSIBLE_HOST_KEY_CHECKING=False
 
 RUN echo "Installing Ansible"; \
     pip3 install --upgrade pip; \
-    pip3 install docker; \
     pip3 install ansible
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM amazonlinux:2023
+
+RUN yum update -y & yum install -y yum-utils shadow-utils gcc libffi-devel python3 python3-pip openssh-clients rsync
+
+ENV ANSIBLE_HOST_KEY_CHECKING=False
+
+RUN echo "Installing Ansible"; \
+    pip3 install --upgrade pip; \
+    pip3 install docker; \
+    pip3 install ansible
+
+
+RUN mkdir /ansible
+COPY ./requirements.yaml /ansible/requirements.yaml
+
+WORKDIR /ansible
+
+# Install dependencies with specific versions
+RUN ansible-galaxy collection install -r requirements.yaml -p ~/collections
+
+RUN cp -r ~/collections/ansible_collections/ ~/.ansible/collections ; rm -rf ~/collections

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build: Dockerfile
+	docker build -t ansible:latest .
+
+run:
+	docker run -it --rm ansible:latest bash

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: community.general
+    version: 8.5.0
+  - name: community.docker
+    version: 3.8.0
+  - name: ansible.posix
+    version: 1.5.4


### PR DESCRIPTION
# What is this PR about?
In order to create ansible as a github action, then we need to create a Docker Image that has ansible installed with the required dependencies. For that reason this image is created and being shipped to our private container registry. This gives us the possibility to use it in custom github actions later.

> [!NOTE] 
> This PR sets up some stuff that can be used to custom github actions. That is, a PR creating the custom github action will be created after this

### What is all of this going to be used for?
The plan is to make a github action that then can be used in our `itu-minitwit` workflows to provision and deploy our applications