### PR TITLE
Add github action to run ansible playbooks

### DIFF
--- a/.github/actions/ansible-run-playbook/Dockerfile
+++ b/.github/actions/ansible-run-playbook/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/devops2024-group-e/ansible:latest
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "bash", "/entrypoint.sh" ]

--- a/.github/actions/ansible-run-playbook/action.yaml
+++ b/.github/actions/ansible-run-playbook/action.yaml
@@ -1,5 +1,5 @@
-name: 'Vansible-Provisioner'
-description: 'Runs vagrant provision with ansible'
+name: 'ansible-playbook-runner'
+description: 'Runs ansible playbooks using the provided inventory and playbook file'
 inputs:
   dotoken:
     description: 'The Digital Ocean token'

--- a/.github/actions/ansible-run-playbook/action.yaml
+++ b/.github/actions/ansible-run-playbook/action.yaml
@@ -1,0 +1,39 @@
+name: 'Vansible-Provisioner'
+description: 'Runs vagrant provision with ansible'
+inputs:
+  dotoken:
+    description: 'The Digital Ocean token'
+    required: true
+  dosshkeyname:
+    description: 'The name of the ssh key in Digital Ocean'
+    required: true
+  sshkey:
+    description: 'The private ssh key to access servers'
+    required: true
+  dockeruser:
+    description: 'The username for the docker registry'
+    required: true
+  dockerpassword:
+    description: 'The password for the docker registry'
+    required: true
+  inventoryfile:
+    description: 'The working directory to run the command in'
+    required: true
+  playbook:
+    description: 'The playbook to run'
+    required: true
+  working-directory:
+    description: 'The working directory to run the command in'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.sshkey}}
+    - ${{ inputs.dockeruser }}
+    - ${{ inputs.dockerpassword }}
+    - ${{ inputs.dotoken }}
+    - ${{ inputs.dosshkeyname }}
+    - ${{ inputs.inventoryfile }}
+    - ${{ inputs.playbook }}
+    - ${{ inputs.working-directory }}

--- a/.github/actions/ansible-run-playbook/entrypoint.sh
+++ b/.github/actions/ansible-run-playbook/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Setup SSH KEY
+echo "Setting up SSH key"
+mkdir -p ~/.ssh/
+echo "$1" > ~/.ssh/do_ssh_key
+chmod 600 ~/.ssh/do_ssh_key
+
+export DOCKER_USERNAME="$2"
+export DOCKER_PASSWORD="$3"
+export DIGITAL_OCEAN_TOKEN="$4"
+export DIGITAL_OCEAN_SSH_KEY_NAME="$5"
+
+cd $8
+
+ansible-playbook --private-key ~/.ssh/do_ssh_key -i $6 $7 --extra-vars "dockeruser=${2} dockerpassword=${3}"


### PR DESCRIPTION
# What is this PR about?
This PR builds on top of what was created in this #1. So here we actually create the custom github action that we are going to reference later in a workflow at `itu-minitwit`. When creating a custom github action, a directory in the `.github` directory has been added called `actions`, just like with workflows. In the `actions` directory we can create sub-folders with the name of the workflow which will contain the specification of the workflow and the logic. In our case, we have created a sub-folder called `ansible-run-playbook` which contains the following files:
- `action.yaml` - Is a specification of what it does and which parameters it has
- `Dockerfile` - Is the image to run. This contains the environment from the Dockerfile in the linked PR. It points and runs the logic which is contained in `entrypoint.sh`
- `entrypoint.sh` - Contains all the logic of the custom action. In here you can see that we run the `ansible-playbook` command